### PR TITLE
fixed repeat-login-request bug

### DIFF
--- a/src/App/components/LandingPage/LandingPage.jsx
+++ b/src/App/components/LandingPage/LandingPage.jsx
@@ -23,6 +23,8 @@ const Auth = props => {
     confirmPassword: ""
   });
 
+  const [isPending, setIsPending] = useState(false);
+
   const AuthContext = useContext(authContext);
   const GlobalContext = useContext(globalContext);
 
@@ -42,11 +44,18 @@ const Auth = props => {
   const onSubmit = async e => {
     e.preventDefault();
 
+    if (isPending) {
+      return;
+    }
+    setIsPending(true);
+
     const { email, password, remember } = loginState;
 
     const loginResponse = await login(email, password);
 
     const { success, token, msg } = loginResponse;
+
+    setIsPending(false);
 
     if (success) {
       message.success("Login successful");
@@ -66,11 +75,18 @@ const Auth = props => {
   const onSubmitRegister = async e => {
     e.preventDefault();
 
+    if (isPending) {
+      return;
+    }
+    setIsPending(true);
+
     const { email, password, confirmPassword } = signUpState;
 
     const signUpResponse = await signUp(email, password, confirmPassword);
 
     const { success, token, msg } = signUpResponse;
+
+    setIsPending(false);
 
     if (success) {
       message.success("Registration successful");
@@ -153,6 +169,7 @@ const Auth = props => {
                     backgroundColor: projectColor,
                     borderColor: projectColor
                   }}
+                  loading={isPending}
                 >
                   <span style={{ fontSize: "16px" }}>Login</span>
                 </Button>
@@ -197,6 +214,7 @@ const Auth = props => {
                     backgroundColor: projectColor,
                     borderColor: projectColor
                   }}
+                  loading={isPending}
                 >
                   <span style={{ fontSize: "16px" }}>Register</span>
                 </Button>
@@ -220,7 +238,7 @@ const LandingContent = () => (
 
 const LandingPage = props => {
   const isLoggedIn = () => {
-    props.history.push("/");
+    props.history.replace("/");
   };
   return (
     <AuthProvider>


### PR DESCRIPTION
Bug:
Users are allowed to send multiple concurrent login/register request to the backend.

Problem: 
The onSubmit functions don't check to see if there is an already pending request. causing the bug.

Solution:
Have a pending state that is set to true when there is a pending request and false when there isn't.
The onSubmit functions should only make a request if the pending state is false.

Note: This PR solves another bug where the user's back button won't work after a successful login/register, because once the user presses the back button it takes them to the landing page. Since the user is already logged in, it will redirect them back to the home page. This makes it impossible to go to any previous history without having to manually open up the history tree.