### PR TITLE
Username is now displayed

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "babel-polyfill": "^6.26.0",
     "classnames": "^2.2.6",
     "customize-cra": "^0.5.0",
+    "jwt-decode": "^2.2.0",
     "lodash": "^4.17.11",
     "prop-types": "^15.7.2",
     "react": "^16.8.6",

--- a/src/App/components/ProfilePage/ProfilePage.jsx
+++ b/src/App/components/ProfilePage/ProfilePage.jsx
@@ -1,8 +1,16 @@
-import React from "react";
+import React, { useContext } from "react";
+import { withRouter } from "react-router-dom";
 import Post from "./components/Post";
 import ProfileHeader from "./components/ProfileHeader";
+import globalContext from "../../context/global/globalContext";
+import getCurrentUserName from "../../util/jwtUtil";
 
-export default function ProfilePage() {
+const ProfilePage = props => {
+  const { state } = useContext(globalContext);
+
+  const username =
+    props.match.params.username || getCurrentUserName(state.authToken);
+
   return (
     <div>
       <Post />
@@ -10,8 +18,10 @@ export default function ProfilePage() {
       <ProfileHeader
         coverImage="https://www.w3schools.com/w3images/avatar2.png"
         profileImage="https://www.w3schools.com/w3images/avatar2.png"
-        displayName="John Doe"
+        displayName={username}
       />
     </div>
   );
-}
+};
+
+export default withRouter(ProfilePage);

--- a/src/App/components/routing/Routes.jsx
+++ b/src/App/components/routing/Routes.jsx
@@ -6,9 +6,7 @@ import NotFoundPage from "../NotFoundPage/NotFoundPage";
 import ProfilePage from "../ProfilePage/ProfilePage";
 import Gallery from "../Gallery/Gallery";
 import NavBar from "../Navbar/Navbar";
-
 import PrivateRoute from "./PrivateRoute";
-
 import GlobalProvider from "../../context/global/GlobalProvider";
 
 export default function Routes() {
@@ -18,7 +16,8 @@ export default function Routes() {
         <Switch>
           <PrivateRoute exact path="/" component={HomePage} />
           <Route exact path="/login" component={LandingPage} />
-          <Route exact path="/profile/:section?" component={ProfilePage} />
+          <PrivateRoute exact path="/profile" component={ProfilePage} />
+          <Route exact path="/profile/:username" component={ProfilePage} />
           <Route exact path="/gallery" component={Gallery} />
           <Route exact path="/navbar" component={NavBar} />
           {/* below line for testing */}

--- a/src/App/util/jwtUtil.js
+++ b/src/App/util/jwtUtil.js
@@ -1,0 +1,8 @@
+import jwtDecode from "jwt-decode";
+
+const getCurrentUserName = token => {
+  const decoded = jwtDecode(token);
+  return decoded.username;
+};
+
+export default getCurrentUserName;

--- a/yarn.lock
+++ b/yarn.lock
@@ -6804,6 +6804,11 @@ just-extend@^4.0.2:
   resolved "https://registry.yarnpkg.com/just-extend/-/just-extend-4.0.2.tgz#f3f47f7dfca0f989c55410a7ebc8854b07108afc"
   integrity sha512-FrLwOgm+iXrPV+5zDU6Jqu4gCRXbWEQg2O3SKONsWE4w7AXFRkryS53bpWdaL9cNol+AmR3AEYz6kn+o0fCPnw==
 
+jwt-decode@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/jwt-decode/-/jwt-decode-2.2.0.tgz#7d86bd56679f58ce6a84704a657dd392bba81a79"
+  integrity sha1-fYa9VmefWM5qhHBKZX3TkruoGnk=
+
 killable@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/killable/-/killable-1.0.1.tgz#4c8ce441187a061c7474fb87ca08e2a638194892"


### PR DESCRIPTION
Username is now displayed whenever we hit:
* The route `/profile` detects your username and displays it. This route is accessible by users only who have `logged in` before hitting that route. If a guest tries to hit that route he will be redirected to the `/login` route.

* The route `/profile/:username` is for finding users without logging. For example `/profile/john ( john is a unique username ) ` if that's you it would show you even if you are not logged but that could be applied to other users such as `/profile/quincy.`