### PR TITLE
error thrown when guest tries is fixed

### DIFF
--- a/src/App/actions/post.js
+++ b/src/App/actions/post.js
@@ -11,9 +11,10 @@ export const getPosts = () => async dispatch => {
   } else {
     setAuthToken(sessionStorage.token);
   }
+  const lastSegment = window.location.pathname.split("/").pop();
 
   try {
-    const res = await axios.get(`${BaseURL}/`);
+    const res = await axios.get(`${BaseURL}/${lastSegment}`);
     dispatch({
       type: GET_POST,
       payload: res.data


### PR DESCRIPTION
* the URL request in the getPosts action is now taking lastParam segment of the url ( kristian of /profile/kristian ) so when a guest tries to visit that profile page it fetches that particular user's post without throwing errors.
* closes #93 